### PR TITLE
fixed bucket domain name

### DIFF
--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -727,7 +727,7 @@ Resources:
     Properties:
       DistributionConfig:
         Origins:
-          - DomainName: !GetAtt WebhostS3Bucket.DomainName
+          - DomainName: !GetAtt WebhostS3Bucket.RegionalDomainName
             Id: s3-webhost
             OriginAccessControlId: !GetAtt CloudFrontOriginAccessControl.Id
             S3OriginConfig:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed the `DomainName` for the CloudFront distribution to reference the `RegionalDomainName` instead. My cloudfront distribution wouldn't work for my bucket deployed in ap-southeast-1 unless I made this change. Suspect that current setup only works in us-east-1. This new change should get it to work in other regions as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
